### PR TITLE
Quote output for raw ls lines

### DIFF
--- a/zsh/commands/filesystem.zsh
+++ b/zsh/commands/filesystem.zsh
@@ -41,7 +41,7 @@ _truncated_ls() {
                                    --format=across \
                                    --color=always \
                                    --width=$COLUMNS)"
-    local RAW_LS_LINES=$(builtin echo -E "$RAW_LS_OUT" | wc -l)
+    local RAW_LS_LINES="$(builtin echo -E "$RAW_LS_OUT" | wc -l)"
 
     if [[ $RAW_LS_LINES -gt $LS_LINES ]]; then
         builtin echo -E "$RAW_LS_OUT" | head -n $(($LS_LINES - 1))


### PR DESCRIPTION
Running the current version on OS X with zsh 5.0.5 results in an 
error: `_truncated_ls:local:x: not an identifier: y`. Quoting the
output of the number of raw ls lines is good practice and resolves
this problem.
